### PR TITLE
Fill all screens [proof of concept] [windows]

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -293,6 +293,7 @@ def toggle():
 			lockDrag.setVisible(True)
 
 			if config['last_toggle'] == 'full_screen': #Fullscreen mode
+				os.system("autohotkey.exe "+os.path.join(os.path.dirname(__file__), "duplicate.ahk"))
 				if isMac:
 					mw.showFullScreen()
 				if isWin and config['MS_Windows_fullscreen_compatibility_mode']: #Graphical issues on windows when using inbuilt method
@@ -357,6 +358,7 @@ def toggle():
 			if isFullscreen: #only change window state if was fullscreen
 				mw.setWindowState(og_window_state)
 				isFullscreen = False
+			os.system("autohotkey.exe "+os.path.join(os.path.dirname(__file__), "extend.ahk"))
 
 			mw.toolbar.web.show()
 			mw.mainLayout.addWidget(mw.reviewer.bottom.web)

--- a/__init__.py
+++ b/__init__.py
@@ -293,7 +293,8 @@ def toggle():
 			lockDrag.setVisible(True)
 
 			if config['last_toggle'] == 'full_screen': #Fullscreen mode
-				os.system("autohotkey.exe "+os.path.join(os.path.dirname(__file__), "duplicate.ahk"))
+				if config['fill_all_screens']:
+					os.system("autohotkey.exe "+os.path.join(os.path.dirname(__file__), "duplicate.ahk"))
 				if isMac:
 					mw.showFullScreen()
 				if isWin and config['MS_Windows_fullscreen_compatibility_mode']: #Graphical issues on windows when using inbuilt method
@@ -358,7 +359,8 @@ def toggle():
 			if isFullscreen: #only change window state if was fullscreen
 				mw.setWindowState(og_window_state)
 				isFullscreen = False
-			os.system("autohotkey.exe "+os.path.join(os.path.dirname(__file__), "extend.ahk"))
+			if config['fill_all_screens']:
+				os.system("autohotkey.exe "+os.path.join(os.path.dirname(__file__), "extend.ahk"))
 
 			mw.toolbar.web.show()
 			mw.mainLayout.addWidget(mw.reviewer.bottom.web)
@@ -499,6 +501,7 @@ def recheckBoxes(*args):
 	lock_shortcut = config['lock_answer_bar_hotkey']
 	dragLocked = config['answer_bar_locked']
 	auto_tog = config['auto_toggle_when_reviewing']
+	fill_all_scr = config['fill_all_screens']
 	rendering_delay = config['rendering_delay']
 	NDAB = config['ND_AnswerBar_enabled']
 	ans_conf_time = config['answer_conf_time']
@@ -540,6 +543,11 @@ def recheckBoxes(*args):
 		auto_toggle.setChecked(True)
 	else:
 		auto_toggle.setChecked(False)
+
+	if fill_all_scr:
+		fill_all_screens.setChecked(True)
+	else:
+		fill_all_screens.setChecked(False)
 
 	if NDAB:
 		nd_answerBar.setChecked(True)
@@ -612,6 +620,12 @@ auto_toggle.setCheckable(True)
 auto_toggle.setChecked(False)
 menu.addAction(auto_toggle)
 auto_toggle.triggered.connect(lambda state, confVal = 'auto_toggle_when_reviewing': menu_select(state,confVal))
+
+fill_all_screens = QAction('Fill All Screens', mw)
+fill_all_screens.setCheckable(True)
+fill_all_screens.setChecked(False)
+menu.addAction(fill_all_screens)
+fill_all_screens.triggered.connect(lambda state, confVal = 'fill_all_screens': menu_select(state,confVal))
 
 menu.addSeparator()
 

--- a/config.json
+++ b/config.json
@@ -13,6 +13,7 @@
 	"answer_bar_posY": 0,
 	"rendering_delay": 500,
 	"auto_toggle_when_reviewing": false,
+	"fill_all_screens": false,
 	"ND_AnswerBar_enabled": false,
 	"answer_conf_time": 0.5,
 	"do_not_show_NDAB_warning": false,

--- a/duplicate.ahk
+++ b/duplicate.ahk
@@ -1,0 +1,12 @@
+﻿;global screentoggled:=false
+;~F11::
+    send #p
+    Sleep, 1000
+    Send {Home}{Down}
+    ;if screentoggled
+    ;   send {Down}
+    send {Enter}
+    Sleep, 1000
+    send {Esc}
+    ;screentoggled := !screentoggled
+;return

--- a/duplicateextendtoggle.ahk
+++ b/duplicateextendtoggle.ahk
@@ -1,0 +1,12 @@
+﻿global screentoggled:=false
+~F11::
+    send #p
+    Sleep, 1000
+    Send {Home}{Down}
+    if screentoggled
+       send {Down}
+    send {Enter}
+    Sleep, 1000
+    send {Esc}
+    screentoggled := !screentoggled
+return

--- a/extend.ahk
+++ b/extend.ahk
@@ -1,0 +1,12 @@
+﻿;global screentoggled:=false
+;~F11::
+    send #p
+    Sleep, 1000
+    Send {Home}{Down}
+    ;if screentoggled
+       send {Down}
+    send {Enter}
+    Sleep, 1000
+    send {Esc}
+    ;screentoggled := !screentoggled
+;return


### PR DESCRIPTION
If you have two monitors and go fullscreen, there can still be distractions on the other screen.
I did this in autohotkey to make f11 go fullscreen as well as duplicate the display to both monitors, and then f11 again to go windowed and extend the displays. (This could be modified to disable the other monitor instead of mirroring it by doing {Down} 0 and 2 times instead of 1 and 2 times.)
I should've rewritten it in python, but I just ran it directly!
It'll auto-fullscreen and auto-clone the display so you have two ankis to look at, and it'll auto-window and auto-extend so you have your screens back.
Disabled by default, respects Auto-Toggle being disabled.

The next step would be to get python to change the projector settings.